### PR TITLE
Changes in refine_sdm for 20A-330 and in make_transient_params

### DIFF
--- a/rfpipe/metadata.py
+++ b/rfpipe/metadata.py
@@ -326,6 +326,19 @@ def sdm_metadata(sdmfile, scan, subscan=1, bdfdir=None):
     meta['spw_nchan'] = scanobj.numchans
     meta['spw_reffreq'] = scanobj.reffreqs
     meta['spw_chansize'] = scanobj.chanwidths
+
+    maxchansize = max(meta['spw_chansize'])
+    mask = np.array(meta['spw_chansize']) == maxchansize
+    if mask.sum() < len(meta['spw_reffreq']):
+        logger.info('Skipping high-resolution spws {0}'.format(np.array(meta['spw_orig'])[~mask].tolist()))
+        
+        assert mask.sum() > 0.5*len(meta['spw_reffreq']), "more than 50% spws removed"
+
+        meta['spw_reffreq'] = np.array(meta['spw_reffreq'])[mask].tolist()
+        meta['spw_nchan'] = np.array(meta['spw_nchan'])[mask].tolist()
+        meta['spw_chansize'] = np.array(meta['spw_chansize'])[mask].tolist()
+        meta['spw_orig'] = np.array(meta['spw_orig'])[mask].tolist()
+
     try:
         meta['pols_orig'] = scanobj.bdf.spws[0].pols('cross')
     except AttributeError:

--- a/rfpipe/reproduce.py
+++ b/rfpipe/reproduce.py
@@ -293,6 +293,14 @@ def refine_sdm(sdmname, dm, preffile='realfast.yml', gainpath='/home/mchammer/ev
         logger.warn("No BDF found for sdmname {0}".format(sdmname))
         return cc
 
+    if '20A-330' in sdmname and len(st.metadata.spw_reffreq) == 16:
+        mask = ~(np.abs(np.array(st.metadata.spw_reffreq) - 1410000000) < 10**6)
+        
+        st.metadata.spw_reffreq = np.array(st.metadata.spw_reffreq)[mask].tolist()
+        st.metadata.spw_nchan = np.array(st.metadata.spw_nchan)[mask].tolist()
+        st.metadata.spw_chansize = np.array(st.metadata.spw_chansize)[mask].tolist()
+        st.metadata.spw_orig = np.array(st.metadata.spw_orig)[mask].tolist()
+
     st.prefs.dmarr = sorted([dm] + [dm0 for dm0 in st.dmarr if (dm0 == 0 or dm0 > dm-ddm)])  # remove superfluous dms, enforce orig dm
     st.clearcache()
     st.summarize()
@@ -321,6 +329,15 @@ def refine_sdm(sdmname, dm, preffile='realfast.yml', gainpath='/home/mchammer/ev
             prefs['npix_max'] = npix_max_orig
             st = state.State(sdmfile=sdmname, sdmscan=1, inprefs=prefs, preffile=preffile, name='NRAOdefault'+band, bdfdir=bdfdir,
                              showsummary=False)
+
+            if '20A-330' in sdmname and len(st.metadata.spw_reffreq) == 16:
+                mask = ~(np.abs(np.array(st.metadata.spw_reffreq) - 1410000000) < 10**6)
+                
+                st.metadata.spw_reffreq = np.array(st.metadata.spw_reffreq)[mask].tolist()
+                st.metadata.spw_nchan = np.array(st.metadata.spw_nchan)[mask].tolist()
+                st.metadata.spw_chansize = np.array(st.metadata.spw_chansize)[mask].tolist()            
+                st.metadata.spw_orig = np.array(st.metadata.spw_orig)[mask].tolist()                    
+            
             st.prefs.dmarr = sorted([dm] + [dm0 for dm0 in st.dmarr if (dm0 == 0 or dm0 > dm-ddm)])  # remove superfluous dms, enforce orig dm
             st.clearcache()
             st.summarize()

--- a/rfpipe/reproduce.py
+++ b/rfpipe/reproduce.py
@@ -293,19 +293,6 @@ def refine_sdm(sdmname, dm, preffile='realfast.yml', gainpath='/home/mchammer/ev
         logger.warn("No BDF found for sdmname {0}".format(sdmname))
         return cc
 
-    maxchansize = max(st.metadata.spw_chansize)
-    mask = np.array(st.metadata.spw_chansize) == maxchansize
-    
-    if mask.sum() < len(st.metadata.spw_reffreq):
-        logging.info('Skipping high-resolution spws {0}'.format(np.array(st.metadata.spw_orig)[~mask].tolist()))
-    
-        assert mask.sum() > 0.5*len(st.metadata.spw_reffreq)
-        
-        st.metadata.spw_reffreq = np.array(st.metadata.spw_reffreq)[mask].tolist()
-        st.metadata.spw_nchan = np.array(st.metadata.spw_nchan)[mask].tolist()
-        st.metadata.spw_chansize = np.array(st.metadata.spw_chansize)[mask].tolist()
-        st.metadata.spw_orig = np.array(st.metadata.spw_orig)[mask].tolist()
-
     st.prefs.dmarr = sorted([dm] + [dm0 for dm0 in st.dmarr if (dm0 == 0 or dm0 > dm-ddm)])  # remove superfluous dms, enforce orig dm
     st.clearcache()
     st.summarize()
@@ -334,19 +321,6 @@ def refine_sdm(sdmname, dm, preffile='realfast.yml', gainpath='/home/mchammer/ev
             prefs['npix_max'] = npix_max_orig
             st = state.State(sdmfile=sdmname, sdmscan=1, inprefs=prefs, preffile=preffile, name='NRAOdefault'+band, bdfdir=bdfdir,
                              showsummary=False)
-
-            maxchansize = max(st.metadata.spw_chansize)
-            mask = np.array(st.metadata.spw_chansize) == maxchansize
-
-            if mask.sum() < len(st.metadata.spw_reffreq):
-                logging.info('Skipping high-resolution spws {0}'.format(np.array(st.metadata.spw_orig)[~mask].tolist()))
-            
-                assert mask.sum() > 0.5*len(st.metadata.spw_reffreq)
-                
-                st.metadata.spw_reffreq = np.array(st.metadata.spw_reffreq)[mask].tolist()
-                st.metadata.spw_nchan = np.array(st.metadata.spw_nchan)[mask].tolist()
-                st.metadata.spw_chansize = np.array(st.metadata.spw_chansize)[mask].tolist()
-                st.metadata.spw_orig = np.array(st.metadata.spw_orig)[mask].tolist()
 
             st.prefs.dmarr = sorted([dm] + [dm0 for dm0 in st.dmarr if (dm0 == 0 or dm0 > dm-ddm)])  # remove superfluous dms, enforce orig dm
             st.clearcache()

--- a/rfpipe/util.py
+++ b/rfpipe/util.py
@@ -526,8 +526,9 @@ def make_transient_params(st, ntr=1, segment=None, dmind=None, dtind=None,
         if dtind is not None:
             dt = st.inttime*st.dtarr[dtind]
         else:
-            max_width = 0.03/st.inttime
-            dt = st.inttime*np.random.uniform(0, max_width) # s  #like an alias for "dt"
+            #max_width = 0.04/st.inttime
+            #dt = st.inttime*np.random.uniform(0, max_width) # s  #like an alias for "dt"
+            dt = np.random.uniform(0.001, 0.04)
             if dt < st.inttime:
                 dtind = 0
             else:
@@ -548,8 +549,11 @@ def make_transient_params(st, ntr=1, segment=None, dmind=None, dtind=None,
 #        dt = random.uniform(min(st.dtarr), max(st.dtarr))
 
         if i is None:
-            i = np.random.randint(0,st.readints) 
-            #i = random.choice(st.get_search_ints(segment, dmind, dtind))
+            ints = np.array(st.get_search_ints(segment, dmind, dtind))*st.dtarr[dtind]
+            i = np.random.randint(min(ints), max(ints))
+            
+            #i = np.random.randint(0,st.readints)
+            #i = random.choice(st.get_search_ints(segment, dmind, dtind))*st.dtarr[dtind]
 
         if amp is None:
             if data is None:


### PR DESCRIPTION
Removing one spw from metadata in 20A-330 observations in refine_sdm, so that automatic refinement can work. 

In make_transient_params:
- Updated calculation of width and set maxwidth to 40ms. 
- Updated calculation of integration to fix the IndexError. 