### PR TITLE
added preference to select calibration mode, added atel_plot, fix in refine_sdm logging

### DIFF
--- a/rfpipe/calibration.py
+++ b/rfpipe/calibration.py
@@ -95,6 +95,9 @@ def getsols(st, threshold=1/10., onlycomplete=True, mode='realtime',
     reffreq, nchan, chansize = st.metadata.spw_sorted_properties
     skyfreqs = np.around([reffreq[i] + (chansize[i]*nchan[i]//2) for i in range(len(nchan))], -6)/1e6  # GN skyfreq is band center
 
+    if st.prefs.calmode == 'best' or st.prefs.calmode == 'realtime':
+        mode = st.prefs.calmode
+    
     sols = select(sols, time=st.segmenttimes.mean(), freqs=skyfreqs, mode=mode)
     if st.prefs.flagantsol:
         sols = flagants(sols, threshold=threshold,

--- a/rfpipe/preferences.py
+++ b/rfpipe/preferences.py
@@ -57,6 +57,7 @@ class Preferences(object):
     apply_chweights = attr.ib(default=False)  # calculate weight per ch and scale data
     apply_blweights = attr.ib(default=False)  # calculate weight per bl and scale data
     max_zerofrac = attr.ib(default=0.8)  # seg zero frac (post flag) to search. also frac of spectrum for kalman calc
+    calmode = attr.ib(default=None)  # set the calibration mode: "realtime", "best" 
     # simulate transients from list of tuples with
     # values/units: (segment, i0/int, dm/pc/cm3, dt/s, amp/sys, dl/rad, dm/rad)
     # or an int that defines number of mocks to create per scan

--- a/rfpipe/reproduce.py
+++ b/rfpipe/reproduce.py
@@ -297,8 +297,8 @@ def refine_sdm(sdmname, dm, preffile='realfast.yml', gainpath='/home/mchammer/ev
             logger.warning("Could not generate state with 2x images. Trying with original image size...")
             prefs['npix_max'] = min(npix_max, npix_max_orig)
             st = state.State(sdmfile=sdmname, sdmscan=1, inprefs=prefs, preffile=preffile, name='NRAOdefault'+band, bdfdir=bdfdir, showsummary=False)
-    except FileNotFoundError:
-        logger.warning("No BDF found for sdmname {0}".format(sdmname))
+    except FileNotFoundError as e:
+        logger.warning("{0}".format(e))
         return cc
 
     st.prefs.dmarr = sorted([dm] + [dm0 for dm0 in st.dmarr if (dm0 == 0 or dm0 > dm-ddm)])  # remove superfluous dms, enforce orig dm


### PR DESCRIPTION
- added preference `calmode` to select calibration solution (realtime or best). Default in `calibration.getsols` is `realtime`, the input preference overrides that 
- added `atel_plot` function to make the 3 panel candidate plot from canddata
- change in logging of `FileNotFoundError` in `refine_sdm`. As `FileNotFoundError` in this function can be caused by either preffile or SDM-BDF file, the error message now shows which file is the cause of the error.